### PR TITLE
Debug MCP server connection in VSCode

### DIFF
--- a/hierarchical_docs_mcp/server.py
+++ b/hierarchical_docs_mcp/server.py
@@ -1,5 +1,6 @@
 """Main MCP server implementation."""
 
+import json
 from typing import Any
 
 from mcp.server import Server
@@ -146,27 +147,27 @@ class DocumentationMCPServer:
                 results = await tools.handle_search_documentation(
                     arguments, self.documents, self.categories, self.config.search_limit
                 )
-                return [{"type": "text", "text": str(results)}]
+                return [{"type": "text", "text": json.dumps(results, indent=2)}]
 
             elif name == "navigate_to":
                 result = await tools.handle_navigate_to(arguments, self.documents, self.categories)
-                return [{"type": "text", "text": str(result)}]
+                return [{"type": "text", "text": json.dumps(result, indent=2)}]
 
             elif name == "get_table_of_contents":
                 result = await tools.handle_get_table_of_contents(
                     arguments, self.documents, self.categories
                 )
-                return [{"type": "text", "text": str(result)}]
+                return [{"type": "text", "text": json.dumps(result, indent=2)}]
 
             elif name == "search_by_tags":
                 results = await tools.handle_search_by_tags(
                     arguments, self.documents, self.config.search_limit
                 )
-                return [{"type": "text", "text": str(results)}]
+                return [{"type": "text", "text": json.dumps(results, indent=2)}]
 
             elif name == "get_document":
                 result = await tools.handle_get_document(arguments, self.documents)
-                return [{"type": "text", "text": str(result)}]
+                return [{"type": "text", "text": json.dumps(result, indent=2)}]
 
             else:
                 raise ValueError(f"Unknown tool: {name}")


### PR DESCRIPTION
The issue was that tool responses were using Python's str() function to convert dictionaries to strings, which produces Python-style dictionary strings with single quotes (e.g., "{'key': 'value'}") instead of valid JSON with double quotes.

This caused the MCP client (GitHub Copilot) to fail when rendering subsequent document responses with the error: "ModelService: Cannot add model because it already exists!"

Changes:
- Import json module in server.py
- Replace all str(result) calls with json.dumps(result, indent=2)
- Applied to all tool handlers: search_documentation, navigate_to, get_table_of_contents, search_by_tags, and get_document

The JSON format is now properly formatted and parseable by MCP clients, resolving the rendering failure issue.

Fixes: Multiple document fetch failures in GitHub Copilot

# Pull Request

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements

## Related Issue

<!-- If this PR addresses an issue, link it here -->

Fixes #(issue number)

## Changes Made

<!-- List the key changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Manual testing completed
- [ ] Integration tests pass

### Test Results

```
# Paste pytest output here
```

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Considerations

<!-- If applicable, describe any security implications of your changes -->

- [ ] No security implications
- [ ] Security review completed
- [ ] Security tests added

## Performance Impact

<!-- Describe any performance implications -->

- [ ] No performance impact
- [ ] Performance improvement
- [ ] Performance degradation (please explain)

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Context

<!-- Add any other context about the PR here -->
