### PR TITLE
fix: resolve template/route data mismatches for web rendering

### DIFF
--- a/docs_mcp/web/routes.py
+++ b/docs_mcp/web/routes.py
@@ -25,36 +25,11 @@ def create_docs_router(
     categories: dict[str, Category],
     config: ServerConfig,
 ) -> APIRouter:
-    """Create the /docs/* router for server-rendered pages.
-
-    Args:
-        documents: All loaded documents
-        categories: Category tree
-        config: Server configuration
-
-    Returns:
-        FastAPI APIRouter
-    """
+    """Create the /docs/* router for server-rendered pages."""
     router = APIRouter()
 
-    # Build ordered document list for prev/next navigation
     doc_map = {d.uri: d for d in documents}
     ordered_docs = sorted(documents, key=lambda d: (str(d.relative_path.parent), d.order, d.title))
-
-    def _get_nav_tree() -> list[dict[str, Any]]:
-        """Build navigation tree for sidebar."""
-        toc = get_table_of_contents(categories, documents)
-        return toc.get("children", [])
-
-    def _get_prev_next(doc: Document) -> tuple[Document | None, Document | None]:
-        """Get previous and next documents in order."""
-        try:
-            idx = ordered_docs.index(doc)
-        except ValueError:
-            return None, None
-        prev_doc = ordered_docs[idx - 1] if idx > 0 else None
-        next_doc = ordered_docs[idx + 1] if idx < len(ordered_docs) - 1 else None
-        return prev_doc, next_doc
 
     def _uri_to_url(uri: str) -> str:
         """Convert a docs:// URI to a /docs/ URL path."""
@@ -63,12 +38,83 @@ def create_docs_router(
             return "/docs/"
         return f"/docs/{path}"
 
-    def _base_context(request: Request) -> dict[str, Any]:
+    def _build_nav_tree(
+        toc_children: list[dict[str, Any]],
+        current_uri: str = "",
+    ) -> list[dict[str, Any]]:
+        """Transform TOC tree into template-expected nav tree format."""
+        items = []
+        for node in toc_children:
+            uri = node.get("uri", "")
+            is_active = uri == current_uri
+            children = _build_nav_tree(node.get("children", []), current_uri)
+            is_expanded = is_active or any(c.get("active") or c.get("expanded") for c in children)
+
+            item: dict[str, Any] = {
+                "label": node.get("name", ""),
+                "url": _uri_to_url(uri) + ("/" if node.get("type") == "category" else ""),
+                "active": is_active,
+                "expanded": is_expanded,
+                "children": children,
+            }
+            items.append(item)
+        return items
+
+    def _get_nav_tree(current_uri: str = "") -> list[dict[str, Any]]:
+        """Build navigation tree for sidebar."""
+        toc = get_table_of_contents(categories, documents)
+        return _build_nav_tree(toc.get("children", []), current_uri)
+
+    def _get_prev_next(
+        doc: Document,
+    ) -> tuple[dict[str, str] | None, dict[str, str] | None]:
+        """Get previous and next documents with url/title."""
+        try:
+            idx = ordered_docs.index(doc)
+        except ValueError:
+            return None, None
+        prev_doc = None
+        next_doc = None
+        if idx > 0:
+            p = ordered_docs[idx - 1]
+            prev_doc = {"title": p.title, "url": _uri_to_url(p.uri)}
+        if idx < len(ordered_docs) - 1:
+            n = ordered_docs[idx + 1]
+            next_doc = {"title": n.title, "url": _uri_to_url(n.uri)}
+        return prev_doc, next_doc
+
+    def _make_breadcrumbs(
+        crumbs: list[dict[str, str]], current_label: str | None = None
+    ) -> list[dict[str, str]]:
+        """Build breadcrumb list with url/label keys."""
+        result = []
+        for crumb in crumbs:
+            result.append(
+                {
+                    "label": crumb["name"],
+                    "url": _uri_to_url(crumb["uri"]) + "/",
+                }
+            )
+        if current_label:
+            result.append({"label": current_label, "url": ""})
+        return result
+
+    def _doc_to_template(doc: Document) -> dict[str, Any]:
+        """Transform a Document into template-expected dict."""
+        return {
+            "title": doc.title,
+            "url": _uri_to_url(doc.uri),
+            "excerpt": doc.excerpt(200),
+            "tags": doc.tags,
+            "last_modified": doc.last_modified.strftime("%Y-%m-%d"),
+        }
+
+    def _base_context(request: Request, current_uri: str = "") -> dict[str, Any]:
         """Common template context."""
         return {
             "request": request,
             "config": config,
-            "nav_tree": _get_nav_tree(),
+            "nav_tree": _get_nav_tree(current_uri),
             "uri_to_url": _uri_to_url,
             "base_url": config.base_url.rstrip("/") if config.base_url else "",
         }
@@ -145,7 +191,7 @@ def create_docs_router(
             {
                 "tag": tag,
                 "tag_counts": tag_counts,
-                "documents_for_tag": matching_docs,
+                "documents_for_tag": [_doc_to_template(d) for d in matching_docs],
                 "uri_to_url": _uri_to_url,
             }
         )
@@ -165,19 +211,19 @@ def create_docs_router(
         # Get child categories
         child_cats = [categories[uri] for uri in cat.child_categories if uri in categories]
 
-        # Get child documents
-        child_docs = [doc_map[uri] for uri in cat.child_documents if uri in doc_map]
+        # Get child documents as template-ready dicts
+        child_docs = [
+            _doc_to_template(doc_map[uri]) for uri in cat.child_documents if uri in doc_map
+        ]
 
-        breadcrumbs = [{"name": "Home", "url": "/docs/"}]
-        for crumb in cat.breadcrumbs:
-            breadcrumbs.append({"name": crumb["name"], "url": _uri_to_url(crumb["uri"]) + "/"})
+        breadcrumbs = _make_breadcrumbs(cat.breadcrumbs)
 
-        ctx = _base_context(request)
+        ctx = _base_context(request, category_uri)
         ctx.update(
             {
                 "category": cat,
-                "child_categories": child_cats,
-                "child_docs": child_docs,
+                "subcategories": child_cats,
+                "documents": child_docs,
                 "breadcrumbs": breadcrumbs,
             }
         )
@@ -197,10 +243,7 @@ def create_docs_router(
         rendered = render_markdown(doc.content)
 
         # Build breadcrumbs
-        breadcrumbs = [{"name": "Home", "url": "/docs/"}]
-        for crumb in get_breadcrumbs(doc.uri):
-            breadcrumbs.append({"name": crumb["name"], "url": _uri_to_url(crumb["uri"]) + "/"})
-        breadcrumbs.append({"name": doc.title, "url": ""})
+        breadcrumbs = _make_breadcrumbs(get_breadcrumbs(doc.uri), doc.title)
 
         # Get prev/next
         prev_doc, next_doc = _get_prev_next(doc)
@@ -211,12 +254,17 @@ def create_docs_router(
             repo = config.github_repo.rstrip("/")
             github_url = f"{repo}/edit/main/{doc.relative_path}"
 
-        ctx = _base_context(request)
+        # Transform headings for template (expects "text" not "name")
+        headings = [
+            {"id": h["id"], "text": h["name"], "level": h["level"]} for h in rendered["toc"]
+        ]
+
+        ctx = _base_context(request, doc_uri)
         ctx.update(
             {
                 "doc": doc,
                 "content_html": rendered["html"],
-                "headings": rendered["toc"],
+                "headings": headings,
                 "breadcrumbs": breadcrumbs,
                 "prev_doc": prev_doc,
                 "next_doc": next_doc,
@@ -234,20 +282,17 @@ def create_docs_router(
         urlset = Element("urlset")
         urlset.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")
 
-        # Add home
         url_el = SubElement(urlset, "url")
         SubElement(url_el, "loc").text = f"{base}/docs/"
         SubElement(url_el, "changefreq").text = "daily"
         SubElement(url_el, "priority").text = "1.0"
 
-        # Add categories
         for cat in categories.values():
             url_el = SubElement(urlset, "url")
             SubElement(url_el, "loc").text = f"{base}{_uri_to_url(cat.uri)}/"
             SubElement(url_el, "changefreq").text = "weekly"
             SubElement(url_el, "priority").text = "0.8"
 
-        # Add documents
         for doc in documents:
             url_el = SubElement(urlset, "url")
             SubElement(url_el, "loc").text = f"{base}{_uri_to_url(doc.uri)}"


### PR DESCRIPTION
## Summary

- Fixed all data shape mismatches between `routes.py` and Jinja2 templates
- Category pages now correctly list documents (was showing "No documents in this category yet")
- Sidebar navigation tree renders with proper labels, URLs, and active state
- Breadcrumbs render with correct label/url keys
- Prev/next navigation works with url/title dicts
- Page TOC headings use correct `text` key

## Root cause

The templates expected specific dict shapes (`url`, `label`, `active`, `expanded`, `children`) but routes were passing raw model objects with different names (`uri`, `name`, `child_docs`, `child_categories`).

## Test plan

- [x] Tested against 91 real docs — all pages render
- [x] `/docs/guides/` shows 8 documents (was 0)
- [x] `/docs/guides/developer-environment` renders markdown with breadcrumbs
- [x] 580 tests pass, coverage > 80%
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)