### PR TITLE
feat: Streamable HTTP MCP transport

### DIFF
--- a/docs_mcp/web/app.py
+++ b/docs_mcp/web/app.py
@@ -1,4 +1,4 @@
-"""Web server for documentation browsing with MCP SSE transport support."""
+"""Web server for documentation browsing with MCP SSE and Streamable HTTP transport support."""
 
 from pathlib import Path
 from typing import Any
@@ -90,14 +90,23 @@ class DocumentationWebServer:
         self.documents = documents
         self.categories = categories
 
-        # Create the MCP server for SSE transport (only if MCP transport is enabled)
+        # Create the MCP server for SSE/Streamable HTTP transport
         if self.config.enable_mcp_transport:
             self.mcp_server = Server("hierarchical-docs-mcp")
             register_mcp_handlers(self.mcp_server, self.documents, self.categories, self.config)
             self.sse_transport = SseServerTransport("/messages/")
+
+            from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+            self.http_session_manager = StreamableHTTPSessionManager(
+                app=self.mcp_server,
+                json_response=False,
+                stateless=False,
+            )
         else:
             self.mcp_server = None
             self.sse_transport = None
+            self.http_session_manager = None
 
         self.app = FastAPI(
             title=config.branding.site_name,
@@ -131,6 +140,7 @@ class DocumentationWebServer:
         self._register_routes()
         if self.config.enable_mcp_transport:
             self._register_mcp_sse_routes()
+            self._register_mcp_http_routes()
 
         # Register HTMX partials BEFORE docs routes (more specific paths first)
         partials_router = create_partials_router(documents, categories, config)
@@ -169,6 +179,34 @@ class DocumentationWebServer:
 
         for route in reversed(sse_routes_app.routes):
             self.app.router.routes.insert(0, route)
+
+    def _register_mcp_http_routes(self) -> None:
+        """Register Streamable HTTP MCP transport at /mcp.
+
+        This endpoint allows MCP clients (e.g. Claude Code) to connect
+        over standard HTTP POST with SSE responses, as an alternative to
+        the legacy SSE+messages transport.
+        """
+        import contextlib
+
+        # Attach lifespan to the main app so sessions are cleaned up on shutdown
+        original_lifespan = self.app.router.lifespan_context
+
+        @contextlib.asynccontextmanager
+        async def combined_lifespan(app: FastAPI):
+            async with contextlib.AsyncExitStack() as stack:
+                if original_lifespan:
+                    await stack.enter_async_context(original_lifespan(app))
+                await stack.enter_async_context(self.http_session_manager.run())
+                yield
+
+        self.app.router.lifespan_context = combined_lifespan
+
+        @self.app.api_route("/mcp", methods=["GET", "POST", "DELETE"])
+        async def mcp_endpoint(request: Request) -> StarletteResponse:
+            """Streamable HTTP MCP endpoint for AI tool access."""
+            logger.info("MCP Streamable HTTP request: %s", request.method)
+            return await self.http_session_manager.handle_request(request)
 
     def _register_routes(self) -> None:
         """Register API routes."""

--- a/tests/integration/test_streamable_http_endpoint.py
+++ b/tests/integration/test_streamable_http_endpoint.py
@@ -1,0 +1,84 @@
+"""Integration test for the Streamable HTTP MCP transport endpoint."""
+
+import asyncio
+import socket
+
+import httpx
+import pytest
+import pytest_asyncio
+import uvicorn
+
+from docs_mcp.core.config import ServerConfig
+from docs_mcp.web.app import DocumentationWebServer
+
+
+def _get_free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest_asyncio.fixture
+async def running_http_server(tmp_path):
+    """Start the documentation web server with Streamable HTTP support on a free port."""
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+
+    config = ServerConfig(docs_root=docs_root)
+    web_server = DocumentationWebServer(config=config, documents=[], categories={})
+
+    port = _get_free_port()
+    server_config = uvicorn.Config(
+        app=web_server.app,
+        host="127.0.0.1",
+        port=port,
+        log_level="error",
+        loop="asyncio",
+    )
+    server = uvicorn.Server(config=server_config)
+
+    server_task = asyncio.create_task(server.serve())
+
+    try:
+        for _ in range(200):
+            if server.started:
+                break
+            await asyncio.sleep(0.05)
+        else:  # pragma: no cover - defensive timeout
+            raise RuntimeError("HTTP test server failed to start in time")
+
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_mcp_endpoint_accepts_post(running_http_server: str):
+    """Ensure the /mcp endpoint accepts POST with JSON-RPC and returns SSE."""
+    async with httpx.AsyncClient(base_url=running_http_server) as client:
+        # Send an MCP initialize request
+        response = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0.0"},
+                },
+            },
+            headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_mcp_endpoint_rejects_get_without_session(running_http_server: str):
+    """GET /mcp without a session ID should return an error."""
+    async with httpx.AsyncClient(base_url=running_http_server) as client:
+        response = await client.get("/mcp")
+        # Without a valid session, GET should return 400 or 405
+        assert response.status_code in (400, 404, 405)


### PR DESCRIPTION
## Summary
- Adds `/mcp` endpoint (GET/POST/DELETE) using `StreamableHTTPSessionManager` from the MCP library
- Enables MCP clients (Claude Code, etc.) to connect over standard HTTP POST with SSE responses
- Activated by the existing `enable_mcp_transport` flag — no new config needed
- Lifespan properly composed with existing FastAPI app for session cleanup

## Context
This enables the Huitzo docs server to accept MCP connections over Streamable HTTP, which is the modern MCP transport. Used by `huitzo mcp setup docs` CLI command to give developers AI access to documentation.

## Test plan
- [ ] Verify existing SSE transport still works (`/sse` + `/messages/`)
- [ ] Test Streamable HTTP endpoint with Claude Code MCP config
- [ ] Verify web UI unaffected when `enable_mcp_transport=False`
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)