### PR TITLE
Fix /docs/tags/* and ship default styling for current templates

### DIFF
--- a/docs_mcp/web/routes.py
+++ b/docs_mcp/web/routes.py
@@ -183,16 +183,47 @@ def create_docs_router(
         ctx.update({"query": q, "results": results})
         return templates.TemplateResponse(request, "search.html", ctx)
 
+    def _build_all_tags(docs: list[Document]) -> list[dict[str, Any]]:
+        """Aggregate frontmatter tags into the shape tags.html expects.
+
+        Returns a list of {name, count, size} sorted alphabetically. ``size``
+        is a 1..5 bucket derived from ``count`` so the tag cloud template can
+        render a weighted display via ``tag-cloud-item--size-N``.
+        """
+        counts: dict[str, int] = {}
+        for d in docs:
+            for tag in d.tags:
+                counts[tag] = counts.get(tag, 0) + 1
+
+        if not counts:
+            return []
+
+        max_count = max(counts.values())
+        min_count = min(counts.values())
+        spread = max_count - min_count
+
+        def bucket(count: int) -> int:
+            if spread == 0:
+                return 3
+            scaled = (count - min_count) / spread
+            return max(1, min(5, 1 + round(scaled * 4)))
+
+        return [
+            {"name": name, "count": count, "size": bucket(count)}
+            for name, count in sorted(counts.items())
+        ]
+
     @router.get("/docs/tags/", response_class=HTMLResponse)
     async def docs_all_tags(request: Request) -> Response:
         """All tags page."""
-        tag_counts: dict[str, int] = {}
-        for doc in documents:
-            for tag in doc.tags:
-                tag_counts[tag] = tag_counts.get(tag, 0) + 1
-
         ctx = _base_context(request)
-        ctx.update({"tag": None, "tag_counts": tag_counts, "documents_for_tag": []})
+        ctx.update(
+            {
+                "tag": None,
+                "all_tags": _build_all_tags(documents),
+                "documents": [],
+            }
+        )
         return templates.TemplateResponse(request, "tags.html", ctx)
 
     @router.get("/docs/tags/{tag}", response_class=HTMLResponse)
@@ -200,18 +231,12 @@ def create_docs_router(
         """Documents filtered by tag."""
         matching_docs = [d for d in documents if tag in d.tags]
 
-        tag_counts: dict[str, int] = {}
-        for doc in documents:
-            for t in doc.tags:
-                tag_counts[t] = tag_counts.get(t, 0) + 1
-
         ctx = _base_context(request)
         ctx.update(
             {
                 "tag": tag,
-                "tag_counts": tag_counts,
-                "documents_for_tag": [_doc_to_template(d) for d in matching_docs],
-                "uri_to_url": _uri_to_url,
+                "all_tags": _build_all_tags(documents),
+                "documents": [_doc_to_template(d) for d in matching_docs],
             }
         )
         return templates.TemplateResponse(request, "tags.html", ctx)

--- a/docs_mcp/web/static/css/docs.css
+++ b/docs_mcp/web/static/css/docs.css
@@ -128,15 +128,72 @@ img {
 }
 
 .site-logo {
-  font-weight: 700;
-  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  font-size: 0.95rem;
   text-decoration: none;
   color: var(--text-primary);
   white-space: nowrap;
+  letter-spacing: -0.01em;
 }
 
 .site-logo:hover {
   color: var(--accent-primary);
+}
+
+.logo-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.logo-text {
+  font-size: 15px;
+}
+
+/* Header search — sits in .header-center, distinct from the standalone
+   .search-form / .search-input used by /docs/search and the 404 page. */
+.header-search {
+  flex: 1;
+  max-width: 480px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.header-search input[type="search"] {
+  width: 100%;
+  padding: 8px 14px 8px 36px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 14px;
+  color: var(--text-primary);
+  transition: border-color 0.15s ease;
+}
+
+.header-search input[type="search"]:focus {
+  border-color: var(--accent-primary);
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -1px;
+}
+
+.header-search input[type="search"]::placeholder {
+  color: var(--text-muted);
+}
+
+.header-search .search-submit {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  font-size: 14px;
 }
 
 .search-form {
@@ -170,20 +227,94 @@ img {
 }
 
 .theme-toggle {
-  background: none;
-  border: none;
+  background-color: transparent;
+  border: 1px solid var(--border-color);
   cursor: pointer;
-  font-size: 1.25rem;
-  padding: 8px;
+  font-size: 16px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-secondary);
   border-radius: var(--radius-sm);
-  transition: background-color 0.2s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .theme-toggle:hover {
   background-color: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
+/* Show only the icon that represents the *target* theme: in dark mode the
+   sun is visible (click to go light); in light mode the moon is visible. */
+.theme-icon-dark { display: none; }
+[data-theme="light"] .theme-icon-light { display: none; }
+[data-theme="light"] .theme-icon-dark { display: inline; }
+
+/* Hamburger menu button (the .hamburger-icon span is empty; we draw three
+   stacked bars from the button itself). Hidden on desktop, surfaced via the
+   responsive block below. */
+.mobile-menu-toggle {
+  display: none;
+  background-color: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  cursor: pointer;
+  margin-right: 8px;
+  position: relative;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.mobile-menu-toggle:hover {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.mobile-menu-toggle .hamburger-icon {
+  display: inline-block;
+  width: 18px;
+  height: 2px;
+  background-color: currentColor;
+  border-radius: 1px;
+  position: relative;
+}
+
+.mobile-menu-toggle .hamburger-icon::before,
+.mobile-menu-toggle .hamburger-icon::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 18px;
+  height: 2px;
+  background-color: currentColor;
+  border-radius: 1px;
+  transition: transform 0.15s ease, top 0.15s ease;
+}
+
+.mobile-menu-toggle .hamburger-icon::before { top: -6px; }
+.mobile-menu-toggle .hamburger-icon::after { top: 6px; }
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-icon {
+  background-color: transparent;
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-icon::before {
+  top: 0;
+  transform: rotate(45deg);
+}
+
+.mobile-menu-toggle[aria-expanded="true"] .hamburger-icon::after {
+  top: 0;
+  transform: rotate(-45deg);
+}
+
+/* Backwards-compat: kept for downstream templates that still emit the older
+   .mobile-menu-btn class. New templates use .mobile-menu-toggle above. */
 .mobile-menu-btn {
   display: none;
   background: none;
@@ -325,6 +456,53 @@ img {
   color: var(--accent-primary);
   background-color: var(--accent-light);
   font-weight: 500;
+}
+
+.sidebar-section {
+  margin-bottom: 28px;
+}
+
+.sidebar-heading {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0 10px;
+  margin: 0 0 8px;
+}
+
+.sidebar-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar-list .sidebar-link,
+.sidebar-section .sidebar-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.sidebar-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  background-color: var(--bg-primary);
+  color: var(--text-muted);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.sidebar-link--active .sidebar-badge {
+  background-color: var(--accent-primary);
+  color: #ffffff;
 }
 
 /* --------------------------------------------------------------------------
@@ -1046,27 +1224,205 @@ h4:hover .header-anchor,
 }
 
 /* --------------------------------------------------------------------------
-   Hero Section
+   Hero Section — used by /docs/ home page (home.html)
    -------------------------------------------------------------------------- */
 .hero {
   text-align: center;
-  padding: 64px 0 48px;
+  padding: 24px 0 48px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 48px;
 }
 
-.hero h1 {
-  font-size: 3rem;
-  font-weight: 800;
-  margin-bottom: 16px;
-  letter-spacing: -0.03em;
+.hero-title {
+  font-size: 44px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
   line-height: 1.1;
+  color: var(--text-primary);
+  margin: 0 0 12px;
 }
 
-.hero p {
-  font-size: 1.25rem;
-  color: var(--text-secondary);
-  max-width: 600px;
+.hero-subtitle {
+  font-size: 18px;
+  color: var(--text-muted);
+  max-width: 580px;
+  margin: 0 auto 28px;
+  line-height: 1.5;
+}
+
+.hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: 40px;
+  margin: 0 0 32px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.stat-value {
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--accent-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 6px;
+}
+
+.hero-search {
+  display: flex;
+  gap: 8px;
+  max-width: 520px;
   margin: 0 auto;
-  line-height: 1.6;
+}
+
+.hero-search-input {
+  flex: 1;
+  padding: 12px 16px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 15px;
+  color: var(--text-primary);
+  transition: border-color 0.15s ease;
+}
+
+.hero-search-input:focus {
+  border-color: var(--accent-primary);
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -1px;
+}
+
+.hero-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.hero-search-btn {
+  padding: 0 22px;
+  background-color: var(--accent-primary);
+  color: #ffffff;
+  border: 0;
+  border-radius: var(--radius);
+  font: inherit;
+  font-weight: 500;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.hero-search-btn:hover {
+  background-color: var(--accent-hover);
+}
+
+/* --------------------------------------------------------------------------
+   Section titles + grids — home page sections, category listings
+   -------------------------------------------------------------------------- */
+.section-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 18px;
+}
+
+.categories-grid,
+.quick-links,
+.subcategories,
+.document-list {
+  margin-bottom: 48px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.category-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px 20px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--text-primary);
+  transition: border-color 0.15s ease, transform 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.category-card:hover {
+  border-color: var(--accent-primary);
+  transform: translateY(-1px);
+}
+
+.category-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.category-card-count {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.category-card-desc {
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  margin: 4px 0 0;
+  line-height: 1.5;
+}
+
+.quick-links-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.quick-link-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--text-primary);
+  font-weight: 500;
+  font-size: 14px;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.quick-link-card:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.quick-link-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.quick-link-label {
+  font-weight: 500;
 }
 
 /* --------------------------------------------------------------------------
@@ -1191,7 +1547,8 @@ h4:hover .header-anchor,
   display: none;
 }
 
-.sr-only {
+.sr-only,
+.visually-hidden {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -1354,4 +1711,178 @@ h4:hover .header-anchor,
 
 .sidebar-overlay.active {
   display: block;
+}
+
+/* --------------------------------------------------------------------------
+   Tags pages — /docs/tags/ and /docs/tags/{tag}
+   -------------------------------------------------------------------------- */
+.tags-page {
+  max-width: var(--content-max-width);
+}
+
+.tags-header {
+  margin-bottom: 32px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.tags-title {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 8px 0;
+}
+
+.tags-count {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.tag-highlight {
+  color: var(--accent-primary);
+}
+
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.tag-cloud-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 500;
+  line-height: 1;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    color 0.15s ease, transform 0.15s ease;
+}
+
+.tag-cloud-item:hover {
+  background-color: var(--accent-light);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  transform: translateY(-1px);
+}
+
+.tag-cloud-label {
+  letter-spacing: 0.01em;
+}
+
+.tag-cloud-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  padding: 2px 6px;
+  background-color: var(--bg-primary);
+  color: var(--text-muted);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.tag-cloud-item:hover .tag-cloud-count {
+  background-color: var(--accent-primary);
+  color: #ffffff;
+}
+
+.tag-cloud-item--size-1 { font-size: 13px; }
+.tag-cloud-item--size-2 { font-size: 14px; }
+.tag-cloud-item--size-3 { font-size: 16px; }
+.tag-cloud-item--size-4 { font-size: 18px; }
+.tag-cloud-item--size-5 { font-size: 20px; }
+
+/* --------------------------------------------------------------------------
+   Document list — used by tag pages and category listings
+   -------------------------------------------------------------------------- */
+.doc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.doc-list-item {
+  padding: 20px 24px;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.doc-list-item:hover {
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.doc-list-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+}
+
+.doc-list-title a {
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.doc-list-title a:hover {
+  color: var(--accent-primary);
+}
+
+.doc-list-excerpt {
+  color: var(--text-secondary);
+  margin: 0 0 12px 0;
+  line-height: 1.6;
+}
+
+.doc-list-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.doc-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.doc-list-date {
+  margin-left: auto;
+}
+
+.tag-pill--small {
+  padding: 1px 8px;
+  font-size: 11px;
+}
+
+.tag-pill--active {
+  background-color: var(--accent-primary);
+  color: #ffffff;
+}
+
+/* --------------------------------------------------------------------------
+   Empty states
+   -------------------------------------------------------------------------- */
+.empty-state {
+  padding: 32px 24px;
+  text-align: center;
+  color: var(--text-muted);
+  background-color: var(--bg-secondary);
+  border: 1px dashed var(--border-color);
+  border-radius: var(--radius);
+  margin-top: 24px;
 }

--- a/tests/integration/test_web_routes.py
+++ b/tests/integration/test_web_routes.py
@@ -182,15 +182,26 @@ class TestDocsTags:
         r = web_client.get("/docs/tags/")
         assert r.status_code == 200
         assert "text/html" in r.headers["content-type"]
+        # Tags from the fixture documents must render in the cloud, not the
+        # empty-state. Regression guard for the routes/template variable
+        # contract — the template reads ``all_tags``.
+        assert "tag-cloud-item" in r.text
+        assert ">intro<" in r.text
+        assert ">advanced<" in r.text
+        assert "No tags have been created yet." not in r.text
 
     def test_specific_tag(self, web_client):
         r = web_client.get("/docs/tags/intro")
         assert r.status_code == 200
         assert "intro" in r.text
+        # Per-tag page must list matching documents (not "0 documents").
+        assert "doc-list-item" in r.text
+        assert "0 documents with this tag" not in r.text
 
     def test_unknown_tag_shows_empty(self, web_client):
         r = web_client.get("/docs/tags/nonexistent")
         assert r.status_code == 200
+        assert "0 documents with this tag" in r.text
 
 
 class TestSEO:


### PR DESCRIPTION
## Summary

- **Bug fix**: The SSR tag handlers in `docs_mcp/web/routes.py` passed `tag_counts` + `documents_for_tag` to `tags.html`, but the template reads `all_tags` and `documents`. The variables never lined up, so:
  - `/docs/tags/` rendered "No tags have been created yet." for projects that have plenty of frontmatter tags
  - `/docs/tags/{tag}` reported "0 documents with this tag" for matching docs
  
  The new `_build_all_tags` helper produces the shape `tags.html` expects, with a 1..5 size bucket derived from relative count so the `.tag-cloud-item--size-N` weighting works.

- **Default styles for current templates**: While verifying the tags fix I noticed the upstream stylesheet doesn't style most of the class names the bundled templates emit — `.header-search` / `.search-submit` (distinct from `.search-form` used by `/docs/search`), `.mobile-menu-toggle` + `.hamburger-icon`, `.visually-hidden`, `.sidebar-section/-heading/-list/-badge`, the entire home-page hero family (`.hero-title`, `.hero-subtitle`, `.hero-stats`, `.stat-*`, `.hero-search`, `.hero-search-input`, `.hero-search-btn`), `.section-title`, `.card-grid`, `.category-card-*`, `.quick-link-card`, plus the `.tag-cloud`, `.doc-list`, and `.empty-state` primitives the tags fix depends on. Added neutral defaults for all of them using the existing CSS variable tokens — no brand colors or font choices baked in.
  
  Replaced the legacy `.hero h1` / `.hero p` selectors with `.hero-title` / `.hero-subtitle` so the cascade matches the bundled `home.html`. Taught `.theme-icon-light` / `.theme-icon-dark` to swap on `data-theme` so the toggle stops rendering both sun and moon at once.

- **Test guard**: The existing `TestDocsTags` only asserted HTTP 200, which is what let the contract drift in the first place. Strengthened it to check `.tag-cloud-item` actually renders, per-tag pages list `.doc-list-item`, and the empty-state fires for unknown tags.

Note: bug #1 mentioned in our discussion (nested doc paths beyond two segments) was already fixed upstream in #73 — this PR only addresses the tag pages and the missing default styling.

## Test plan
- [x] \`pytest tests/integration/test_web_routes.py\` — 32/32 pass
- [x] \`ruff check\` / \`ruff format --check\` — clean
- [x] Reproduced both bugs locally against a real docs tree (115 docs, 23 categories), confirmed fix renders the tag cloud (216 tags, weighted) and per-tag listings (e.g. \`/docs/tags/architecture\` → 21 docs)
- [x] Visual check of \`/docs/\`, doc pages, and tag pages in both light and dark themes
- [x] Confirmed downstream overlays loaded via \`MCP_DOCS_BRANDING_CUSTOM_CSS_URL\` still take precedence (overlay loads after \`docs.css\`, so brand colors/fonts continue to win)